### PR TITLE
Add minimal FastAPI-based CRM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # 32-Real-Estate-CRM
-CRM
+
+This project provides a minimal Real Estate CRM built with FastAPI and SQLAlchemy. It allows managing clients and property listings via RESTful endpoints.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the App
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Running Tests
+
+```bash
+pytest
+```

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,18 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./crm.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,99 @@
+from typing import List
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import Base, engine, get_db
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Real Estate CRM")
+
+
+@app.post("/clients/", response_model=schemas.Client)
+def create_client(client: schemas.ClientCreate, db: Session = Depends(get_db)):
+    db_client = models.Client(**client.dict())
+    db.add(db_client)
+    db.commit()
+    db.refresh(db_client)
+    return db_client
+
+
+@app.get("/clients/", response_model=List[schemas.Client])
+def read_clients(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    clients = db.query(models.Client).offset(skip).limit(limit).all()
+    return clients
+
+
+@app.get("/clients/{client_id}", response_model=schemas.Client)
+def read_client(client_id: int, db: Session = Depends(get_db)):
+    client = db.query(models.Client).filter(models.Client.id == client_id).first()
+    if not client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    return client
+
+
+@app.put("/clients/{client_id}", response_model=schemas.Client)
+def update_client(client_id: int, client: schemas.ClientCreate, db: Session = Depends(get_db)):
+    db_client = db.query(models.Client).filter(models.Client.id == client_id).first()
+    if not db_client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    for key, value in client.dict().items():
+        setattr(db_client, key, value)
+    db.commit()
+    db.refresh(db_client)
+    return db_client
+
+
+@app.delete("/clients/{client_id}")
+def delete_client(client_id: int, db: Session = Depends(get_db)):
+    db_client = db.query(models.Client).filter(models.Client.id == client_id).first()
+    if not db_client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    db.delete(db_client)
+    db.commit()
+    return {"ok": True}
+
+
+@app.post("/properties/", response_model=schemas.Property)
+def create_property(property: schemas.PropertyCreate, db: Session = Depends(get_db)):
+    db_property = models.Property(**property.dict())
+    db.add(db_property)
+    db.commit()
+    db.refresh(db_property)
+    return db_property
+
+
+@app.get("/properties/", response_model=List[schemas.Property])
+def read_properties(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return db.query(models.Property).offset(skip).limit(limit).all()
+
+
+@app.get("/properties/{property_id}", response_model=schemas.Property)
+def read_property(property_id: int, db: Session = Depends(get_db)):
+    prop = db.query(models.Property).filter(models.Property.id == property_id).first()
+    if not prop:
+        raise HTTPException(status_code=404, detail="Property not found")
+    return prop
+
+
+@app.put("/properties/{property_id}", response_model=schemas.Property)
+def update_property(property_id: int, property: schemas.PropertyCreate, db: Session = Depends(get_db)):
+    db_property = db.query(models.Property).filter(models.Property.id == property_id).first()
+    if not db_property:
+        raise HTTPException(status_code=404, detail="Property not found")
+    for key, value in property.dict().items():
+        setattr(db_property, key, value)
+    db.commit()
+    db.refresh(db_property)
+    return db_property
+
+
+@app.delete("/properties/{property_id}")
+def delete_property(property_id: int, db: Session = Depends(get_db)):
+    db_property = db.query(models.Property).filter(models.Property.id == property_id).first()
+    if not db_property:
+        raise HTTPException(status_code=404, detail="Property not found")
+    db.delete(db_property)
+    db.commit()
+    return {"ok": True}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, Integer, String, Float, Boolean, ForeignKey
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class Client(Base):
+    __tablename__ = "clients"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=False)
+    phone = Column(String, nullable=True)
+
+    properties = relationship("Property", back_populates="client", cascade="all, delete-orphan")
+
+
+class Property(Base):
+    __tablename__ = "properties"
+
+    id = Column(Integer, primary_key=True, index=True)
+    address = Column(String, nullable=False)
+    price = Column(Float, nullable=False)
+    sold = Column(Boolean, default=False)
+    client_id = Column(Integer, ForeignKey("clients.id"))
+
+    client = relationship("Client", back_populates="properties")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,38 @@
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class PropertyBase(BaseModel):
+    address: str
+    price: float
+    sold: bool = False
+
+
+class PropertyCreate(PropertyBase):
+    pass
+
+
+class Property(PropertyBase):
+    id: int
+    client_id: Optional[int]
+
+    class Config:
+        orm_mode = True
+
+
+class ClientBase(BaseModel):
+    name: str
+    email: str
+    phone: Optional[str] = None
+
+
+class ClientCreate(ClientBase):
+    pass
+
+
+class Client(ClientBase):
+    id: int
+    properties: List[Property] = []
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+pytest
+httpx

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -1,0 +1,48 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.database import Base, get_db
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base.metadata.create_all(bind=engine)
+
+def override_get_db():
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+
+client = TestClient(app)
+
+def test_create_and_read_client():
+    response = client.post("/clients/", json={"name": "John Doe", "email": "john@example.com"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["email"] == "john@example.com"
+
+    response = client.get("/clients/")
+    assert response.status_code == 200
+    clients = response.json()
+    assert len(clients) == 1
+    assert clients[0]["name"] == "John Doe"
+
+
+def test_create_property():
+    response = client.post(
+        "/properties/",
+        json={"address": "123 Main St", "price": 250000.0, "sold": False, "client_id": 1},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["address"] == "123 Main St"
+    response = client.get("/properties/")
+    assert response.status_code == 200
+    props = response.json()
+    assert len(props) == 1


### PR DESCRIPTION
## Summary
- scaffold a simple Real Estate CRM with FastAPI and SQLAlchemy
- add REST endpoints for clients and properties with Pydantic schemas
- include tests, requirements, and documentation

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement fastapi)
- `pytest` (fails: ModuleNotFoundError: No module named 'fastapi')

------
https://chatgpt.com/codex/tasks/task_e_68988f0b2e80832dbc64ea06e4c74c61